### PR TITLE
Add the ability to ignore the BG list per area

### DIFF
--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -230,6 +230,7 @@ class AOClient : public QObject {
         {"SAVETEST",        1ULL << 12},
         {"FORCE_CHARSELECT",1ULL << 13},
         {"BYPASS_LOCKS",    1ULL << 14},
+        {"IGNORE_BGLIST",   1ULL << 15},
         {"SUPER",          ~0ULL      }
     };
 
@@ -962,6 +963,15 @@ class AOClient : public QObject {
     * @iscommand
     */
     void cmdJudgeLog(int argc, QStringList argv);
+
+    /**
+     * @brief Toggles whether the BG list is ignored in an area.
+     *
+     * @details No arguments.
+     *
+     * @iscommand
+     */
+    void cmdIgnoreBgList(int argc, QStringList argv);
 
     ///@}
 
@@ -2055,6 +2065,8 @@ class AOClient : public QObject {
         {"updateban",          {ACLFlags.value("BAN"),          3, &AOClient::cmdUpdateBan}},
         {"update_ban",         {ACLFlags.value("BAN"),          3, &AOClient::cmdUpdateBan}},
         {"changepass",         {ACLFlags.value("NONE"),         1, &AOClient::cmdChangePassword}},
+        {"ignorebglist",       {ACLFlags.value("IGNORE_BGLIST"),0, &AOClient::cmdIgnoreBgList}},
+        {"ignore_bglist",      {ACLFlags.value("IGNORE_BGLIST"),0, &AOClient::cmdIgnoreBgList}}
     };
 
     /**

--- a/core/include/area_data.h
+++ b/core/include/area_data.h
@@ -797,8 +797,22 @@ class AreaData : public QObject {
      * @brief Returns a copy of the underlying logger's buffer.
      *
      * @return See short description.
+     *
+     * @see #m_ignoreBgList
      */
     QQueue<QString> buffer() const;
+
+    /**
+     * @brief Returns whether the BG list is ignored in this araa.
+     *
+     * @return See short description.
+     */
+    bool ignoreBgList();
+
+    /**
+     * @brief Toggles whether the BG list is ignored in this area.
+     */
+    void toggleIgnoreBgList();
 
 private:
     /**
@@ -983,6 +997,11 @@ private:
      * @brief Whether or not music is allowed in this area. If false, only CMs can change the music.
      */
     bool m_toggleMusic;
+
+    /**
+     * @brief Whether or not to ignore the server defined background list. If true, any background can be set in an area.
+     */
+    bool m_ignoreBgList;
 };
 
 #endif // AREA_DATA_H

--- a/core/src/area_data.cpp
+++ b/core/src/area_data.cpp
@@ -47,6 +47,7 @@ AreaData::AreaData(QString p_name, int p_index) :
     m_forceImmediate = areas_ini.value("force_immediate", "false").toBool();
     m_toggleMusic = areas_ini.value("toggle_music", "true").toBool();
     m_shownameAllowed = areas_ini.value("shownames_allowed", "true").toBool();
+    m_ignoreBgList = areas_ini.value("ignore_bglist", "false").toBool();
     areas_ini.endGroup();
     QSettings config_ini("config/config.ini", QSettings::IniFormat);
     config_ini.setIniCodec("UTF-8");
@@ -533,4 +534,14 @@ bool AreaData::shownameAllowed() const
 QString AreaData::background() const
 {
     return m_background;
+}
+
+bool AreaData::ignoreBgList()
+{
+    return m_ignoreBgList;
+}
+
+void AreaData::toggleIgnoreBgList()
+{
+    m_ignoreBgList = !m_ignoreBgList;
 }

--- a/core/src/commands/area.cpp
+++ b/core/src/commands/area.cpp
@@ -239,7 +239,7 @@ void AOClient::cmdSetBackground(int argc, QStringList argv)
 {
     AreaData* area = server->areas[current_area];
     if (authenticated || !area->bgLocked()) {
-        if (server->backgrounds.contains(argv[0])) {
+        if (server->backgrounds.contains(argv[0]) || area->ignoreBgList() == true) {
             area->background() = argv[0];
             server->broadcast(AOPacket("BN", {argv[0]}), current_area);
             sendServerMessageArea(current_char + " changed the background to " + argv[0]);
@@ -304,4 +304,12 @@ void AOClient::cmdJudgeLog(int argc, QStringList argv)
         QString filteredmessage = message.remove(QRegularExpression("[(].*[)]")); //Filter out anything between two parentheses. This should only ever be the IPID
         sendServerMessage(filteredmessage);
     }
+}
+
+void AOClient::cmdIgnoreBgList(int argc, QStringList argv)
+{
+    AreaData* area = server->areas[current_area];
+    area->toggleIgnoreBgList();
+    QString state = area->ignoreBgList() ? "ignored." : "enforced.";
+    sendServerMessage("BG list in this area is now " + state);
 }


### PR DESCRIPTION
- Adds the "ignore_bglist" option to areas, which toggles whether the BG list is enforced or ignored in an area.
- Adds a moderator permission "IGNORE_BGLIST" to give moderators the permission to toggle this setting.
- Adds a moderator command `/ignorebglist` to toggle this for an area.